### PR TITLE
Add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "17.0.3",
   "description": "full emoji list, unicode v17.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Fixes usage:

(node:48357) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/node_modules/full-emoji-list/index.js:1
import fullEmojiList from './full-emoji-list.json' with { type: 'json' }; 
^^^^^^

SyntaxError: Cannot use import statement outside a module